### PR TITLE
Avoid NPE in HMaster.stopMaster()

### DIFF
--- a/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1612,8 +1612,10 @@ Server {
 
   @Override
   public void stopMaster() throws IOException{
-    cpHost.preStopMaster();
-    stop("Stopped by " + Thread.currentThread().getName());
+    if (cpHost != null) {
+      cpHost.preStopMaster();
+      stop("Stopped by " + Thread.currentThread().getName());
+    }
   }
 
   @Override


### PR DESCRIPTION
Creating the pull request  for y94 as this bug was introduced there, it doesn't exist in 0.94
